### PR TITLE
Change the default path for CRUD helpers to be lower case

### DIFF
--- a/pkg/gofr/crud_helpers.go
+++ b/pkg/gofr/crud_helpers.go
@@ -21,7 +21,7 @@ func getRestPath(object any, structName string) string {
 		return v.RestPath()
 	}
 
-	return structName
+	return strings.ToLower(structName)
 }
 
 func hasAutoIncrementID(constraints map[string]sql.FieldConstraints) bool {


### PR DESCRIPTION
## Pull Request Template


**Description:**

If the structure contains a capital letter the default path will contain also the capital letter. Since path are case sensitive only on some servers it creates confusion. To avoid it, the paths in the url's are converted to lower case by default.

**Breaking Changes (if applicable):**

- on servers which are case sensitive and the provider published them case sensitive from the default it can create a breaking change.

 
**Checklist:**

-   [x] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [x] All new code is covered by unit tests.
-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.

**Thank you for your contribution!**

